### PR TITLE
Added ts_rank_cd function

### DIFF
--- a/Sources/SwifQL/Functions.swift
+++ b/Sources/SwifQL/Functions.swift
@@ -50,7 +50,7 @@ extension Fn {
         //Array
         case array_agg
         //Text Search
-        case to_tsvector, to_tsquery, plainto_tsquery
+        case to_tsvector, to_tsquery, plainto_tsquery, ts_rank_cd
         //Mysql
         case from_unixtime
         //custom
@@ -181,6 +181,7 @@ extension Fn {
             case .to_tsvector: return "to_tsvector"
             case .to_tsquery: return "to_tsquery"
             case .plainto_tsquery: return "plainto_tsquery"
+            case .ts_rank_cd: return "ts_rank_cd"
                 
             case .from_unixtime: return "FROM_UNIXTIME"
                 
@@ -1734,6 +1735,29 @@ extension Fn {
             parts.append(contentsOf: text.parts)
         }
         return buildFn(.plainto_tsquery, body: parts)
+    }
+    
+    /// PostgreSQL provides two predefined ranking functions, which take into account lexical, proximity,
+    /// and structural information; that is, they consider how often the query terms appear in the document,
+    /// how close together the terms are in the document, and how important is the part of the document where they occur.
+    
+    /// `ts_rank_rd` calculates the rank of the provided tsquery
+    /// ts_rank_rd(vector tsvector, query tsquery [, normalization integer ]) returns tsquery
+    /// # Example
+    /// ```swift
+    /// Fn.ts_rank_cd("rats", Fn.to_tsquery("The Fat Rats"))
+    /// ```
+    /// # Result
+    /// ```
+    /// ts_rank_cd("rats", to_tsquery('The Fat Rats'))
+    /// ```
+    /// [Learn more →](https://www.postgresql.org/docs/9.6/textsearch-controls.html#TEXTSEARCH-RANKING)
+    public static func ts_rank_cd(_ vector: SwifQLable, _ query: SwifQLable) -> SwifQLable {
+        var parts: [SwifQLPart] = vector.parts
+        parts.append(o: .comma)
+        parts.append(o: .space)
+        parts.append(contentsOf: query.parts)
+        return buildFn(.ts_rank_cd, body: parts)
     }
     
     // MARK: - MySQL

--- a/Tests/SwifQLTests/SwifQLTests.swift
+++ b/Tests/SwifQLTests/SwifQLTests.swift
@@ -661,6 +661,19 @@ final class SwifQLTests: XCTestCase {
         checkAllDialects(query2, pg: pg2, mySQL: mySQL2)
     }
     
+    // MARK: - Fn.ts_rank_cd
+    
+    func testFn_ts_rank_cd() {
+        let query = SwifQL.select(Fn.ts_rank_cd(FormattedKeyPath(CarBrands.self, "id"), Fn.to_tsquery("The Fat Rats")))
+        let pg = """
+        SELECT ts_rank_cd("CarBrands"."id", to_tsquery('The Fat Rats'))
+        """
+        let mySQL = """
+        SELECT ts_rank_cd(CarBrands.id, to_tsquery('The Fat Rats'))
+        """
+        checkAllDialects(query, pg: pg, mySQL: mySQL)
+    }
+    
     // MARK: - FormattedKeyPath
     
     func testFormattedKeyPath() {


### PR DESCRIPTION
This PR adds the Postgres fts `ts_rank_cd` function (see: https://www.postgresql.org/docs/9.6/textsearch-controls.html#TEXTSEARCH-RANKING)