### PR TITLE
Added UNION and WITH

### DIFF
--- a/Sources/SwifQL/SwifQLable+With.swift
+++ b/Sources/SwifQL/SwifQLable+With.swift
@@ -9,27 +9,41 @@ import Foundation
 
 //MARK: With
 
+/// SELECT in WITH
+/// WITH provides a way to write auxiliary statements for use in a larger query.
+/// These statements, which are often referred to as Common Table Expressions or CTEs,
+/// can be thought of as defining temporary tables that exist just for one query.
+/// Each auxiliary statement in a WITH clause can be a SELECT, INSERT, UPDATE, or DELETE;
+/// and the WITH clause itself is attached to a primary statement that can also be a
+/// SELECT, INSERT, UPDATE, or DELETE.
+/// ```
+/// SwifQL
+///     .with(.init(Table("Table1"), SwifQL.select(Table("Table2").*).from(Table("Table2"))))
+///     .select(Table("Table1").*)
+///     .from(Table("Table1"))
+/// ```
+/// Result
+/// ```
+/// WITH "Table1" as (SELECT "Table2".* FROM "Table2") SELECT "Table1".* FROM "Table1"
+/// ```
+/// https://www.postgresql.org/docs/11/queries-with.html
+///
 extension SwifQLable {
-    public var with: SwifQLable {
-        var parts = self.parts
-        parts.appendSpaceIfNeeded()
-        parts.append(o: .with)
-        return SwifQLableParts(parts: parts)
+    public func with(_ withs: With...) -> SwifQLable {
+        return with(withs)
     }
-    public func with(_ fields: SwifQLable...) -> SwifQLable {
-        return with(fields)
-    }
-    public func with(_ fields: [SwifQLable]) -> SwifQLable {
+    
+    public func with(_ withs: [With]) -> SwifQLable {
         var parts = self.parts
         parts.appendSpaceIfNeeded()
         parts.append(o: .with)
         parts.append(o: .space)
-        for (i, v) in fields.enumerated() {
+        for (i, v) in withs.enumerated() {
             if i > 0 {
                 parts.append(o: .comma)
                 parts.append(o: .space)
             }
-            parts.append(contentsOf: v.parts)
+            parts += v.parts
         }
         return SwifQLableParts(parts: parts)
     }

--- a/Sources/SwifQL/Union.swift
+++ b/Sources/SwifQL/Union.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  Union.swift
+//  SwifQL
 //
 //  Created by Taylor McIntyre on 2020-01-15.
 //

--- a/Sources/SwifQL/Union.swift
+++ b/Sources/SwifQL/Union.swift
@@ -1,0 +1,32 @@
+//
+//  File.swift
+//  
+//
+//  Created by Taylor McIntyre on 2020-01-15.
+//
+
+import Foundation
+
+//MARK: UNION
+
+public class Union: SwifQLable {
+    public var parts: [SwifQLPart]
+    
+    public convenience init (_ selection: SwifQLable...) {
+        self.init(selection)
+    }
+    
+    public init (_ selections: [SwifQLable]) {
+        parts = [SwifQLPartOperator.openBracket]
+        for (i, v) in selections.enumerated() {
+            if i > 0 {
+                parts.append(o: .space)
+                parts.append(o: .union)
+                parts.append(o: .space)
+                parts.append(o: .openBracket)
+            }
+            parts.append(contentsOf: v.parts)
+            parts.append(o: .closeBracket)
+        }
+    }
+}

--- a/Sources/SwifQL/With.swift
+++ b/Sources/SwifQL/With.swift
@@ -1,0 +1,36 @@
+//
+//  With.swift
+//  SwifQL
+//
+//  Created by Taylor McIntyre on 2020-01-16.
+//
+
+import Foundation
+
+//MARK: WITH
+
+public class With: SwifQLable {
+    public var parts: [SwifQLPart]
+    
+    public init(_ table: SwifQLable, columns: [SwifQLable] = [], _ query: SwifQLable) {
+        parts = table.parts
+        if !columns.isEmpty {
+            parts.append(o: .space)
+            parts.append(o: .openBracket)
+            for (i, v) in columns.enumerated() {
+                if i > 0 {
+                    parts.append(o: .comma)
+                    parts.append(o: .space)
+                }
+                parts += v.parts
+            }
+            parts.append(o: .closeBracket)
+        }
+        parts.append(o: .space)
+        parts.append(o: .as)
+        parts.append(o: .space)
+        parts.append(o: .openBracket)
+        parts += query.parts
+        parts.append(o: .closeBracket)
+    }
+}

--- a/Tests/SwifQLTests/SwifQLTests.swift
+++ b/Tests/SwifQLTests/SwifQLTests.swift
@@ -654,7 +654,7 @@ final class SwifQLTests: XCTestCase {
     func testSubqueryWithAlias() {
         let a = CarBrands.as("a")
         let b = CarBrands.as("b")
-// WRONG EXAMPLE because of `|` postfix operator near `alias1`
+        // WRONG EXAMPLE because of `|` postfix operator near `alias1`
 //        let query = SwifQL.select(
 //            a~\.name,
 //            |SwifQL.select(Fn.json_agg(=>"alias1") => "test1" )
@@ -665,8 +665,8 @@ final class SwifQLTests: XCTestCase {
 //                ) => "alias1"|
 //            )
 //            .from(a.table)
-// RIGHT EXAMPLE
-// so use subquery inside brackets or even better move it into variable (it'd be more beautiful and easy to support)
+        // RIGHT EXAMPLE
+        // so use subquery inside brackets or even better move it into variable (it'd be more beautiful and easy to support)
         let query = SwifQL.select(
             a.column("name"),
             |(SwifQL.select(Fn.json_agg(=>"alias1") => "test1")

--- a/Tests/SwifQLTests/SwifQLTests.swift
+++ b/Tests/SwifQLTests/SwifQLTests.swift
@@ -411,7 +411,6 @@ final class SwifQLTests: XCTestCase {
         (SELECT Table1.* FROM Table1) UNION (SELECT Table2.* FROM Table2) UNION (SELECT Table3.* FROM Table3)
         """)
         
-        //Distinct(t1~\.name => .text => "name")
         let adv = SwifQL
             .select(Distinct(Column("uniqueName")) => .text => "name")
             .from(

--- a/Tests/SwifQLTests/SwifQLTests.swift
+++ b/Tests/SwifQLTests/SwifQLTests.swift
@@ -987,7 +987,6 @@ final class SwifQLTests: XCTestCase {
         ("testBingingForMySQL", testBingingForMySQL),
         ("testExists", testExists),
         ("testNotExists", testNotExists),
-        ("testPureWhere", testWhere),
         ("testUnion", testUnion),
         ("testWhereExists", testWhereExists),
         ("testWhereNotExists", testWhereNotExists),

--- a/Tests/SwifQLTests/SwifQLTests.swift
+++ b/Tests/SwifQLTests/SwifQLTests.swift
@@ -654,19 +654,19 @@ final class SwifQLTests: XCTestCase {
     func testSubqueryWithAlias() {
         let a = CarBrands.as("a")
         let b = CarBrands.as("b")
-        // WRONG EXAMPLE because of `|` postfix operator near `alias1`
-        //        let query = SwifQL.select(
-        //            a~\.name,
-        //            |SwifQL.select(Fn.json_agg(=>"alias1") => "test1" )
-        //                .from(
-        //                    |SwifQL.select(b~\.name => "someName")
-        //                        .from(b.table)
-        //                        .where(b~\.id == a~\.id)|
-        //                ) => "alias1"|
-        //            )
-        //            .from(a.table)
-        // RIGHT EXAMPLE
-        // so use subquery inside brackets or even better move it into variable (it'd be more beautiful and easy to support)
+// WRONG EXAMPLE because of `|` postfix operator near `alias1`
+//        let query = SwifQL.select(
+//            a~\.name,
+//            |SwifQL.select(Fn.json_agg(=>"alias1") => "test1" )
+//                .from(
+//                    |SwifQL.select(b~\.name => "someName")
+//                        .from(b.table)
+//                        .where(b~\.id == a~\.id)|
+//                ) => "alias1"|
+//            )
+//            .from(a.table)
+// RIGHT EXAMPLE
+// so use subquery inside brackets or even better move it into variable (it'd be more beautiful and easy to support)
         let query = SwifQL.select(
             a.column("name"),
             |(SwifQL.select(Fn.json_agg(=>"alias1") => "test1")
@@ -675,7 +675,7 @@ final class SwifQLTests: XCTestCase {
                         .from(b.table)
                         .where(b.column("id") == a.column("id"))|
                 ) => "alias1")|
-        )
+            )
             .from(a.table)
         checkAllDialects(query, pg: """
         SELECT "a"."name", (SELECT json_agg("alias1") as "test1" FROM (SELECT "b"."name" as "someName" FROM "CarBrands" AS "b" WHERE "b"."id" = "a"."id") as "alias1") FROM "CarBrands" AS "a"


### PR DESCRIPTION
## UNION
Added support for `UNION`, modelled after `DISTINCT`

```swift
Union(
    SwifQL.select(Table("Table1").*).from(Table("Table1")),
    SwifQL.select(Table("Table2").*).from(Table("Table2"))
)

// (SELECT "Table1".* FROM "Table1") UNION (SELECT "Table2".* FROM "Table2")
// (SELECT Table1.* FROM Table1) UNION (SELECT Table2.* FROM Table2)
```

> Not sure if we want to force the brackets around selections in the union (see example), personally I like it for viewing the raw queries, but its not necessary so maybe it should be removed
```sql
(SELECT "Table1".* FROM "Table1") UNION (SELECT "Table2".* FROM "Table2")
-- vs
SELECT "Table1".* FROM "Table1" UNION SELECT "Table2".* FROM "Table2"
```

## WITH
Supported in PSQL, don't know if its supported in mysql
```swift
SwifQL
    .with(.init(Table("Table1"), SwifQL.select(Table("Table2").*).from(Table("Table2"))))
    .select(Table("Table1").*)
    .from(Table("Table1"))

// WITH "Table1" as (SELECT "Table2".* FROM "Table2") SELECT "Table1".* FROM "Table1"
```
> There was some with implementation already but I wasn't sure what it did or how it was supposed to be used

Would definitely take suggestions for api for `WITH` as I'm not super excited about it (but it works)